### PR TITLE
Update helm chart links

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -80,9 +80,9 @@ Once all prerequisites are on the Linux host, follow the steps below to clone an
 __Note:__ If you are using a local insecure docker registry, ensure you configure the insecure registries on each of the Kubernetes worker nodes to allow access to the local docker repository
 
 ## Deploying Karavi Topology
-Karavi Topology is deployed using Helm.  Usage information and available release versions can be found here: https://github.com/dell/helm-charts/charts/karavi-topology.
+Karavi Topology is deployed using Helm.  Usage information and available release versions can be found here: https://github.com/dell/helm-charts/tree/main/charts/karavi-topology.
 
-If you built the Karavi Topology Docker image and pushed it to a local registry, you can deploy it using the same Helm chart above.  You simply need to override the helm chart value pointing to where the Karavi Topology image lives.  See https://github.com/dell/helm-charts/charts/karavi-topology for more details.
+If you built the Karavi Topology Docker image and pushed it to a local registry, you can deploy it using the same Helm chart above.  You simply need to override the helm chart value pointing to where the Karavi Topology image lives.  See https://github.com/dell/helm-charts/tree/main/charts/karavi-topology for more details.
 
 ## Testing Karavi Topology
 


### PR DESCRIPTION
# Description
This PR updates the karavi-topology helm chart links in the docks/GETTING_STARTED_GUIDE.md to the correct links.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    [#11](https://github.com/dell/karavi-topology/issues/11)  Helm chart links in documentation are broken    | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manually verified that the updated links work as expected.

# Make check output
Copy and paste the results output from running 'make check':

```
./scripts/check.sh ./cmd/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
```

# Make test output
Copy and paste the results output from running 'make test':

```
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-topology/cmd/topology    [no test files]
ok      github.com/dell/karavi-topology/internal/entrypoint     0.028s  coverage: 100.0% of statements
?       github.com/dell/karavi-topology/internal/entrypoint/mocks       [no test files]
ok      github.com/dell/karavi-topology/internal/k8s    0.065s  coverage: 94.4% of statements
?       github.com/dell/karavi-topology/internal/k8s/mocks      [no test files]
ok      github.com/dell/karavi-topology/internal/service        0.069s  coverage: 91.2% of statements
?       github.com/dell/karavi-topology/internal/service/mocks  [no test files]
```