### PR TITLE
Added feature request rejection scenario to issue triage doc

### DIFF
--- a/docs/ISSUE_TRIAGE.md
+++ b/docs/ISSUE_TRIAGE.md
@@ -75,7 +75,7 @@ By default a feature request will be created with the `type/feature-request` and
 Once a feature request has been triaged and prioritized the label should be changed to `type/feature`.
 
 <!-- https://textik.com/#81e81fc717f63429 -->
-```                                                                                                                                 
+```         
                                             +---------------------------------+                                                  
                                             |New feature request issue opened/|                                                  
                                             |more information added           |                                                  
@@ -92,17 +92,22 @@ Once a feature request has been triaged and prioritized the label should be chan
     |Comment `Duplicate of #<issue number>` | YES +----------|----------+                                                        
     |Remove needs-triage label              -------  Duplicate issue?   |                                                        
     |label: triage/duplicate                |     |                     |                                                        
-    +-----------------|---------------------+     +-----------|---------+                                                        
-                      |                                       |                                                                  
-                      |                                    NO |                                                                  
-                      |                        +--------------|---------------+                                                  
-                      |                        | Assign priority              |                                                  
-                      |                        | label: priority/*            |                                                  
-                      |                        | label: type/feature          |                                                  
-           +----------|-----+    +--------+    | Remove needs-triage label    |                                                  
-           | Close issue    |    |  Done  ------ Remove type/feature-request  |                                                  
-           |                |    |        |    | milestone?                   |                                                  
-           +----------------+    +--------+    +------------------------------+                                                                                                               
+    +-----|---------------------------------+     +-----------|---------+                                                        
+          |                                                   |NO                                                                
+          |  +-------------------------+  NO   +-----------------------------+                                                   
+          |  |Add comment              |--------  Does feature request align |                                                   
+          |  |Remove needs-triage label|       |  with product vision?       |                                                   
+          |  +------|------------------+       +--------------|--------------+                                                   
+          |         |                                         | YES                                                              
+          |         |                                         |                                                                  
+          |         |                         +---------------|--------------+                                                   
+          |         |                         | Assign priority              |                                                   
+          |         |                         | label: priority/*            |                                                   
+          |         |                         | label: type/feature          |                                                   
+        +-|---------|---+       +--------+    | Remove needs-triage label    |                                                   
+        |  Close issue  |       |  Done  ------ Remove type/feature-request  |                                                   
+        |               |       |        |    | milestone?                   |                                                   
+        +---------------+       +--------+    +------------------------------+                                                   
 ```
 
 ## 1. Find issues that need triage
@@ -185,7 +190,8 @@ If it's not perfectly clear that it's an actual bug, quickly try to reproduce it
 
 ### Feature request?
 
-1. Move on to [prioritizing the issue](#4-prioritization-of-issues).  Assign the appropriate priority label to the issue, add the appropriate comments to the issue, and remove the `needs-triage` label.
+1. If the feature request does not align with the product vision, add a comment indicating so, remove the `needs-triage` label and close the issue
+2. Otherwise, move on to [prioritizing the issue](#4-prioritization-of-issues).  Assign the appropriate priority label to the issue, add the appropriate comments to the issue, and remove the `needs-triage` label.
 
 ## 4. Prioritization of issues
 


### PR DESCRIPTION
# Description
The issue triage doc does not have anything in it to account for rejecting a feature request when it does not align with the product vision.  This change takes care of adding details for handling that scenario to the doc.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #21      | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Document review