### PR TITLE
Update documentation to specify all 3rd party services must run in the same cluster as Karavi services

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -33,7 +33,7 @@ Karavi Topology current has support for the following Dell EMC storage systems a
 
 ### Grafana
 
-Volume visibility is provided through the karavi-topology service and Grafana.  This service exposes an endpoint that can be consumed by Grafana to display CSI driver provisioned volume characteristics correlated with volumes on the storage system.  The [topology Grafana dashboard](../grafana/dashboards/dashboards) requires the following version of Grafana deployed in the k8s cluster. 
+Volume visibility is provided through the karavi-topology service and Grafana.  This service exposes an endpoint that can be consumed by Grafana to display CSI driver provisioned volume characteristics correlated with volumes on the storage system.  The [topology Grafana dashboard](../grafana/dashboards/dashboards) requires the following version of Grafana deployed in the k8s cluster running the karavi-topology service. 
 
 
 | Supported Version | Image                   | Helm Chart                                                |
@@ -47,12 +47,12 @@ Grafana must be configured with the following data sources/plugins:
 | JSON data source       | https://grafana.com/grafana/plugins/simpod-json-datasource                 |
 | Data Table plugin      | https://grafana.com/grafana/plugins/briangann-datatable-panel/installation |
 
-- Configure the Grafana JSON data source:
+Configure the Grafana JSON data source:
  
 | Setting | Value                             |
 | ------- | --------------------------------- |
 | Name    | JSON |
-| URL     | If your Grafana instance is running within the same Kubernetes cluster as Karavi Topology, you can access Karavi Topology at http://karavi-topology.*namespace*.svc.cluster.local:8080.<br><br>If your Grafana instance is running in a different cluster than Karavi Topology, you can access Karavi Topology by following the [chart instructions](https://github.com/dell/helm-charts/blob/main/charts/karavi-topology/templates/NOTES.txt) if Karavi Topology was deployed as a `NodePort`. Alternatively, an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) and an [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) can be deployed in the Kubernetes cluster running Karavi Toplogy to manage external access to the default ClusterIP configuration of Karavi Topology. The Karavi Topology service URL would then be the URL allocated by the Ingress controller to satisfy the Ingress.  |
+| URL     | Access Karavi Topology at http://karavi-topology.*namespace*.svc.cluster.local:8080|
 
 ## Building Karavi Topology (Linux Only)
 


### PR DESCRIPTION
# Description
This PR updates the Getting Started document to specify that Grafana must run in the same cluster as Karavi topology service.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|[31](https://github.com/dell/karavi-topology/issues/31)| 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

N/A

# Make check output
N/A

# Make test output
N/A