### PR TITLE
Reverting instructions added for running Karavi Topology in standalone

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -76,29 +76,9 @@ Once all prerequisites are on the Linux host, follow the steps below to clone an
 __Note:__ If you are using a local insecure docker registry, ensure you configure the insecure registries on each of the Kubernetes worker nodes to allow access to the local docker repository
 
 ## Deploying Karavi Topology
-Karavi Topology will be deployed using Helm. A developer can deploy Karavi Topology as standalone service.
-
-### Helm Deployment
 Karavi Topology is deployed using Helm.  Usage information and available release versions can be found here: https://github.com/dell/helm-charts/tree/main/charts/karavi-topology.
 
 If you built the Karavi Topology Docker image and pushed it to a local registry, you can deploy it using the same Helm chart above.  You simply need to override the helm chart value pointing to where the Karavi Topology image lives.  See https://github.com/dell/helm-charts/tree/main/charts/karavi-topology for more details.
-
-### Standalone Deployment
-If you want to run Karavi Toplogy in standalone mode, built the Karavi Topology in your development environment. You can run Go command.
-```console
-$ go run <path to main.go>/main.go
-
-or
-
-$cd ../karavi-topology/cmd/topology
-$ go run main.go
-```
-Following environment variables are required to be set:
-| Environment Variable | Description                  |
-| -------------------- | ---------------------------- |
-| PROVISIONER_NAMES    | Comma-separated external-provisioner names. The external-provisioner is a sidecar container that dynamically provisions volumes by calling ControllerCreateVolume and ControllerDeleteVolume functions for CSI drivers. An example, `csi-vxflexos.dellemc.com ` |
-| TLS_CERT_PATH        | Location of the signed certificate file |
-| TLS_KEY_PATH         | Location of the signed certificate private key file |
 
 ## Testing Karavi Topology
 


### PR DESCRIPTION
# Description
Reverting instructions added for running Karavi Topology in standalone mode.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #1        | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Documentation update

# Make check output
Copy and paste the results output from running 'make check':

```insert make check results output here```

# Make test output
Copy and paste the results output from running 'make test':

```insert make test results output here```