### PR TITLE
Adding vxflexos csi-driver version 1.2.1 to supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Karavi Topology currently has support for the following Dell EMC storage systems
 
 | Dell EMC Storage Product | CSI Driver |
 | ----------------------- | ---------- |
-| PowerFlex v3.0/3.5 | [CSI Driver for PowerFlex v1.1.5, 1.2.0](https://github.com/dell/csi-vxflexos) |
+| PowerFlex v3.0/3.5 | [CSI Driver for PowerFlex v1.1.5, 1.2.0, 1.2.1](https://github.com/dell/csi-vxflexos) |
 
 ## Topology Data
 


### PR DESCRIPTION
# Description

Adding VxFlexOS CSI Driver 1.2.1 to the list of qualified drivers.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|      #33     |

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have made corresponding changes to the documentation