### PR TITLE
Update JSON datasource references to grafana-simple-json-datasource

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -59,7 +59,7 @@ Grafana must be configured with the following pre-requisite plugins:
 
 | Name                   | Additional Information                                                     |
 | ---------------------- | -------------------------------------------------------------------------- |
-| JSON data source       | [JSON data source](https://grafana.com/grafana/plugins/simpod-json-datasource)                 |
+| JSON data source       | [JSON data source](https://grafana.com/grafana/plugins/grafana-simple-json-datasource)                 |
 | Data Table plugin      | [Data Table plugin](https://grafana.com/grafana/plugins/briangann-datatable-panel/installation) |
 
 #### Configure Topology Data Source

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -36,7 +36,7 @@ type VolumeInfoGetter interface {
 	GetPersistentVolumes() ([]k8s.VolumeInfo, error)
 }
 
-// TableResponse is the expected response for getting a list of volumes (reference: https://grafana.com/grafana/plugins/simpod-json-datasource)
+// TableResponse is the expected response for getting a list of volumes (reference: https://grafana.com/grafana/plugins/grafana-simple-json-datasource)
 type TableResponse struct {
 	Columns []map[string]string `json:"columns"`
 	Rows    [][]string          `json:"rows"`


### PR DESCRIPTION
# Description

This PR updates documentation and code references to support the `grafana-simple-json-datasource` instead of `simpod-json-datasource`. No logic changes are required for karavi-topology to work with `grafana-simple-json-datasource`.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #66      |

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

This was tested by manually deploying Grafana with grafana-simple-json-datasource and verifying that the datasource is configured in Grafana and that the Kubernetes Admin Dashboard shows volume relationships when IO is running.