### PR TITLE
Make karavi-topology listening port configurable

### DIFF
--- a/cmd/topology/main.go
+++ b/cmd/topology/main.go
@@ -56,7 +56,7 @@ func main() {
 	if portEnv != "" {
 		var err error
 		if bindPort, err = strconv.Atoi(portEnv); err != nil {
-			fmt.Fprintf(os.Stderr, "PORT value is valid '%s'", portEnv)
+			fmt.Fprintf(os.Stderr, "PORT value is invalid: '%s'", portEnv)
 			os.Exit(1)
 		}
 	}

--- a/cmd/topology/main.go
+++ b/cmd/topology/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/dell/karavi-topology/internal/entrypoint"
@@ -50,10 +51,21 @@ func main() {
 		keyFile = defaultKeyFile
 	}
 
+	var bindPort int
+	portEnv := os.Getenv("PORT")
+	if portEnv != "" {
+		var err error
+		if bindPort, err = strconv.Atoi(portEnv); err != nil {
+			fmt.Fprintf(os.Stderr, "PORT value is valid '%s'", portEnv)
+			os.Exit(1)
+		}
+	}
+
 	svc := &service.Service{
 		VolumeFinder: volumeFinder,
 		CertFile:     certFile,
 		KeyFile:      keyFile,
+		Port:         bindPort,
 	}
 
 	if err := entrypoint.Run(context.Background(), svc); err != nil {

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -22,6 +22,14 @@ The topology service requires a Kubernetes cluster that aligns with the supporte
 | --------- |
 | 1.17-1.19 |
 
+## Openshift
+
+For Openshift, the topology service requires the cluster to align with these supported versions.
+
+| Version |
+| ------- |
+| 4.5,4.6 |
+
 ## Supported Dell EMC Products
 
 The topology service currently supports the following versions of Dell EMC storage systems.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -28,6 +28,7 @@ type Service struct {
 	VolumeFinder VolumeInfoGetter
 	CertFile     string
 	KeyFile      string
+	Port         int
 }
 
 // VolumeInfoGetter is an interface used to get a list of volume information
@@ -48,7 +49,10 @@ func (s *Service) Run() error {
 	if s.CertFile == "" || s.KeyFile == "" {
 		return fmt.Errorf("One or more TLS certificates not supplied: CertFile: %s, KeyFile: %s", s.CertFile, s.KeyFile)
 	}
-	return http.ListenAndServeTLS(fmt.Sprintf(":%d", port), s.CertFile, s.KeyFile, s.Routes())
+	if s.Port == 0 {
+		s.Port = port
+	}
+	return http.ListenAndServeTLS(fmt.Sprintf(":%d", s.Port), s.CertFile, s.KeyFile, s.Routes())
 }
 
 // Routes contains the list of routes for the service

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -195,24 +195,37 @@ func TestHttpServerStartup(t *testing.T) {
 		}
 	}
 
-	tests := map[string]func(t *testing.T) (string, string, []checkFn, bool){
-		"error no certs": func(*testing.T) (string, string, []checkFn, bool) {
+	tests := map[string]func(t *testing.T) (string, string, int, []checkFn, bool){
+		"error no certs": func(*testing.T) (string, string, int, []checkFn, bool) {
 			certFile := ""
 			keyFile := ""
 
-			return certFile, keyFile, []checkFn{expectedError}, true
+			return certFile, keyFile, 0, []checkFn{expectedError}, true
+		},
+		"invalid certs": func(*testing.T) (string, string, int, []checkFn, bool) {
+			certFile := "/not-valid-certs/ca.crt"
+			keyFile := "/not-valid-certs/key.file"
+
+			return certFile, keyFile, 0, []checkFn{expectedError}, true
+		},
+		"port specified - invalid certs": func(*testing.T) (string, string, int, []checkFn, bool) {
+			certFile := "/not-valid-certs/ca.crt"
+			keyFile := "/not-valid-certs/key.file"
+
+			return certFile, keyFile, 8443, []checkFn{expectedError}, true
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			certFile, keyFile, checkFns, expectError := tc(t)
+			certFile, keyFile, port, checkFns, expectError := tc(t)
 
 			ctx, teardown := setup(nil)
 			defer teardown()
 			ctx.svc.CertFile = certFile
 			ctx.svc.KeyFile = keyFile
+			ctx.svc.Port = port
 
 			err := ctx.svc.Run()
 


### PR DESCRIPTION
# Description

Make the listening port that the karavi-topology service binds to configurable. OpenShift deployment needs to use higher number port because pods run unprivileged. 

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    https://github.com/dell/helm-charts/issues/54    |

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Manual test with Openshift deployment. Create an image, deployed to internal docker repo, referenced the image in values.yaml, ran helm deployment. Then ran manual e2e test.
