### PR TITLE
Removed -quiet arg from gosec action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Go Security
         uses: securego/gosec@master
-        with:
-          args: -quiet ./... 
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Remvoe the -quiet arg from the gosec action to avoid suppressing security errors 

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    https://github.com/dell/karavi-observability/issues/38      |

# Checklist

- [x] I have performed a self-review of my own code

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] GitHub checks have validated the change
