### PR TITLE
Fix GO security check issue

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -10,11 +10,14 @@ package service
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/dell/karavi-topology/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -61,7 +64,33 @@ func (s *Service) Run() error {
 	if s.Port == 0 {
 		s.Port = port
 	}
-	return http.ListenAndServeTLS(fmt.Sprintf(":%d", s.Port), s.CertFile, s.KeyFile, s.Routes())
+
+	cert, err := tls.LoadX509KeyPair(s.CertFile, s.KeyFile)
+	if err != nil {
+		return fmt.Errorf("tls.LoadX509KeyPair(%s, %s) failed: ", s.CertFile, s.KeyFile)
+	}
+
+	addr := fmt.Sprintf(":%d", s.Port)
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	server := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler:           s.Routes(),
+		TLSConfig:         config,
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on tcp port %d", s.Port)
+	}
+	defer ln.Close()
+	tlsListener := tls.NewListener(ln, config)
+
+	return server.Serve(tlsListener)
 }
 
 // Routes contains the list of routes for the service


### PR DESCRIPTION
# Description
Fix the alert "Use of net/http serve function that has no support for setting timeouts"
Replace `http.ListenAndServeTLS` with `server.Serve`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|N/A|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
``` bash
karavi-topology git:(back/bugfix-go-security-check) ✗ make check test
./scripts/check.sh ./cmd/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-topology/cmd/topology    [no test files]
ok      github.com/dell/karavi-topology/internal/entrypoint     0.031s  coverage: 100.0% of statements
?       github.com/dell/karavi-topology/internal/entrypoint/mocks       [no test files]
ok      github.com/dell/karavi-topology/internal/k8s    0.069s  coverage: 94.1% of statements
?       github.com/dell/karavi-topology/internal/k8s/mocks      [no test files]
ok      github.com/dell/karavi-topology/internal/service        0.088s  coverage: 93.1% of statements
?       github.com/dell/karavi-topology/internal/service/mocks  [no test files]
?       github.com/dell/karavi-topology/internal/tracers        [no test files]
```

- [x] GUI check
![image](https://user-images.githubusercontent.com/105041111/195746179-72468207-cbcb-4de1-83b3-aa0999d1dd5a.png)

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources
- [x] Yes
- [ ] No

