### PR TITLE
go version bump-up

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -60,8 +60,10 @@ jobs:
     name: Image Scanner
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go lastest
+      - name: Set up Go 1.22+
         uses: actions/setup-go@v5
+        with:
+          go-version: ^1.22
         id: go
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/karavi-topology
 
-go 1.21
+go 1.22
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22